### PR TITLE
Fix building scripts player lookup

### DIFF
--- a/scripts/buildings/Molkerei.gd
+++ b/scripts/buildings/Molkerei.gd
@@ -1,6 +1,6 @@
 extends StaticBody2D
 
-@onready var player: CharacterBody2D = %Player
+@onready var player: CharacterBody2D = get_tree().get_first_node_in_group("Player")
 @onready var door_area: Area2D = $DoorArea
 @onready var door: AnimatedSprite2D = $Door
 @onready var building_label: Label = $MolkereiLabel # Reference to the label

--- a/scripts/buildings/Weberei.gd
+++ b/scripts/buildings/Weberei.gd
@@ -1,6 +1,6 @@
 extends StaticBody2D
 
-@onready var player: CharacterBody2D = %Player
+@onready var player: CharacterBody2D = get_tree().get_first_node_in_group("Player")
 @onready var door_area: Area2D = $DoorArea
 @onready var door: AnimatedSprite2D = $Door
 @onready var building_label: Label = $WebereiLabel 

--- a/scripts/buildings/scheune.gd
+++ b/scripts/buildings/scheune.gd
@@ -1,7 +1,7 @@
 extends StaticBody2D
 
 
-@onready var player: CharacterBody2D = %Player
+@onready var player: CharacterBody2D = get_tree().get_first_node_in_group("Player")
 @onready var ui: PanelContainer = $CanvasLayer/ui
 @onready var door_area: Area2D = $DoorArea
 @onready var door: AnimatedSprite2D = $door


### PR DESCRIPTION
## Summary
- fix referencing the player by node group in building scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684016a9fa348327bbfc40a42a5189eb