### PR TITLE
Fix player node lookup across scenes

### DIFF
--- a/scripts/buildings/Futterhaus.gd
+++ b/scripts/buildings/Futterhaus.gd
@@ -1,6 +1,6 @@
 extends StaticBody2D
 
-@onready var player: CharacterBody2D = %Player
+var player: CharacterBody2D
 @onready var door_area: Area2D = $DoorArea
 @onready var garage_door_area: Area2D = $GarageDoorArea
 @onready var door: AnimatedSprite2D = $Door
@@ -16,11 +16,12 @@ var in_garage_door_area = false
 var player_in_feed_area: bool = false
 
 func _ready() -> void:
-	if building_label:
-		building_label.hide()
-	# Verbinde die Signale
-	if player:
-		player.interact.connect(_on_player_interact)
+        player = get_tree().get_first_node_in_group("Player")
+        if building_label:
+                building_label.hide()
+        # Verbinde die Signale
+        if player:
+                player.interact.connect(_on_player_interact)
 	
 	door_area.body_entered.connect(_on_door_area_entered)
 	door_area.body_exited.connect(_on_door_area_exited)

--- a/scripts/buildings/Molkerei.gd
+++ b/scripts/buildings/Molkerei.gd
@@ -1,6 +1,6 @@
 extends StaticBody2D
 
-@onready var player: CharacterBody2D = %Player
+var player: CharacterBody2D
 @onready var door_area: Area2D = $DoorArea
 @onready var door: AnimatedSprite2D = $Door
 @onready var building_label: Label = $MolkereiLabel # Reference to the label
@@ -9,13 +9,14 @@ var in_door_area = false
 var interior_scene_path = "res://scenes/buildings/Molkerei_interior.tscn"
 
 func _ready() -> void:
-	# Hide label initially
-	if building_label:
-		building_label.hide()
-		
-	# Verbinde die Signale
-	if player:
-		player.interact.connect(_on_player_interact)
+        player = get_tree().get_first_node_in_group("Player")
+        # Hide label initially
+        if building_label:
+                building_label.hide()
+
+        # Verbinde die Signale
+        if player:
+                player.interact.connect(_on_player_interact)
 	
 	door_area.body_entered.connect(_on_door_area_entered)
 	door_area.body_exited.connect(_on_door_area_exited)

--- a/scripts/buildings/Pub.gd
+++ b/scripts/buildings/Pub.gd
@@ -1,6 +1,6 @@
 extends StaticBody2D
 
-@onready var player: CharacterBody2D = %Player
+var player: CharacterBody2D
 @onready var door_area: Area2D = $DoorArea
 @onready var door: AnimatedSprite2D = $door
 
@@ -8,9 +8,10 @@ var in_door_area = false
 var interior_scene_path = "res://scenes/buildings/Pub_interior.tscn"
 
 func _ready() -> void:
-	# Verbinde die Signale
-	if player:
-		player.interact.connect(_on_player_interact)
+        player = get_tree().get_first_node_in_group("Player")
+        # Verbinde die Signale
+        if player:
+                player.interact.connect(_on_player_interact)
 	
 	door_area.body_entered.connect(_on_door_area_entered)
 	door_area.body_exited.connect(_on_door_area_exited)

--- a/scripts/buildings/Weberei.gd
+++ b/scripts/buildings/Weberei.gd
@@ -1,6 +1,6 @@
 extends StaticBody2D
 
-@onready var player: CharacterBody2D = %Player
+var player: CharacterBody2D
 @onready var door_area: Area2D = $DoorArea
 @onready var door: AnimatedSprite2D = $Door
 @onready var building_label: Label = $WebereiLabel 
@@ -9,11 +9,12 @@ var in_door_area = false
 var interior_scene_path = "res://scenes/buildings/Weberei_interior.tscn"
 
 func _ready() -> void:
-	if building_label:
-		building_label.hide()
-	# Verbinde die Signale
-	if player:
-		player.interact.connect(_on_player_interact)
+        player = get_tree().get_first_node_in_group("Player")
+        if building_label:
+                building_label.hide()
+        # Verbinde die Signale
+        if player:
+                player.interact.connect(_on_player_interact)
 	
 	door_area.body_entered.connect(_on_door_area_entered)
 	door_area.body_exited.connect(_on_door_area_exited)

--- a/scripts/buildings/markt.gd
+++ b/scripts/buildings/markt.gd
@@ -1,7 +1,7 @@
 extends StaticBody2D
 
 
-@onready var player: CharacterBody2D = %Player
+var player: CharacterBody2D
 @onready var ui_markt: PanelContainer = $CanvasLayer/ui_markt
 @onready var ui_selection: PanelContainer = $CanvasLayer/ui_selection
 @onready var interact_area: Area2D = $interact_area
@@ -16,16 +16,17 @@ var player_in_area: bool = false
 
 
 func _ready() -> void:
-	# CRITICAL FIX: Set CanvasLayer to handle inputs properly
-	canvas_layer.layer = 100  # Put it on top of other layers
+        player = get_tree().get_first_node_in_group("Player")
+        # CRITICAL FIX: Set CanvasLayer to handle inputs properly
+        canvas_layer.layer = 100  # Put it on top of other layers
 	
 	# Ensure UI elements are hidden at start
 	ui_markt.hide()
 	ui_selection.hide()
 	
-	# Connect signals
-	if player:
-		player.interact.connect(_on_player_interact)
+        # Connect signals
+        if player:
+                player.interact.connect(_on_player_interact)
 	interact_area.body_entered.connect(_on_player_entered)
 	interact_area.body_exited.connect(_on_player_exited)
 	ui_markt.select_item.connect(_on_select)

--- a/scripts/buildings/scheune.gd
+++ b/scripts/buildings/scheune.gd
@@ -1,7 +1,7 @@
 extends StaticBody2D
 
 
-@onready var player: CharacterBody2D = %Player
+var player: CharacterBody2D
 @onready var ui: PanelContainer = $CanvasLayer/ui
 @onready var door_area: Area2D = $DoorArea
 @onready var door: AnimatedSprite2D = $door
@@ -10,8 +10,9 @@ var in_area = false
 
 
 func _ready() -> void:
-	if player:
-		player.interact.connect(_on_player_interact)
+        player = get_tree().get_first_node_in_group("Player")
+        if player:
+                player.interact.connect(_on_player_interact)
 	door_area.body_entered.connect(_on_player_entered)
 	door_area.body_exited.connect(_on_player_exited)
 	

--- a/scripts/buildings/shop.gd
+++ b/scripts/buildings/shop.gd
@@ -1,7 +1,7 @@
 extends StaticBody2D
 
 
-@onready var player: CharacterBody2D = %Player
+var player: CharacterBody2D
 @onready var door: Area2D = $door
 @onready var door_sprite: AnimatedSprite2D = $door/AnimatedSprite2D
 @onready var ui_shop: PanelContainer = $CanvasLayer/ui_shop
@@ -10,9 +10,11 @@ var player_in_area: bool = false
 
 
 func _ready() -> void:
-	player.interact.connect(_on_player_interact)
-	door.body_entered.connect(_on_player_entered)
-	door.body_exited.connect(_on_player_exited)
+        player = get_tree().get_first_node_in_group("Player")
+        if player:
+                player.interact.connect(_on_player_interact)
+        door.body_entered.connect(_on_player_entered)
+        door.body_exited.connect(_on_player_exited)
 	
 	
 func _on_player_interact() -> void:

--- a/scripts/buildings/task_caravan.gd
+++ b/scripts/buildings/task_caravan.gd
@@ -1,7 +1,7 @@
 extends StaticBody2D
 
 
-@onready var player: CharacterBody2D = %Player
+var player: CharacterBody2D
 @onready var ui_task_caravan: PanelContainer = $CanvasLayer/ui_task_caravan
 @onready var area: Area2D = $Area2D
 @onready var door: AnimatedSprite2D = $AnimatedSprite2D
@@ -10,8 +10,9 @@ var in_area: bool
 
 
 func _ready() -> void:
-	if player:
-		player.interact.connect(_on_player_interact)
+        player = get_tree().get_first_node_in_group("Player")
+        if player:
+                player.interact.connect(_on_player_interact)
 	area.body_entered.connect(_player_entered)
 	area.body_exited.connect(_player_exited)
 

--- a/scripts/characters/npcs/wandering.gd
+++ b/scripts/characters/npcs/wandering.gd
@@ -6,14 +6,15 @@ class_name NPCWander
 @export var navigation_agent: NavigationAgent2D
 @onready var interaction_area: Area2D = $"../../InteractArea"
 
-@onready var player = %Player
+var player: CharacterBody2D
 
 var move_speed:float = 3.0
 @onready var timer:Timer = $Timer
 
 func _ready() -> void:
-	timer.timeout.connect(make_path)
-	make_path()
+        player = get_tree().get_first_node_in_group("Player")
+        timer.timeout.connect(make_path)
+        make_path()
 
 func physics_update(delta:float) -> void:
 	var dir = npc.to_local(navigation_agent.get_next_path_position()).normalized()

--- a/scripts/farming/farming_area.gd
+++ b/scripts/farming/farming_area.gd
@@ -1,6 +1,6 @@
 extends Area2D
 
-@onready var player:CharacterBody2D = %Player
+var player: CharacterBody2D
 @onready var canvas_group: CanvasGroup = $CanvasGroup
 @onready var ui_farming: PanelContainer = $CanvasLayer/ui_farming
 @onready var camera:Camera2D = $Camera2D
@@ -19,7 +19,8 @@ signal crop_used
 
 
 func _ready() -> void:
-	field_list = canvas_group.get_children()
+        player = get_tree().get_first_node_in_group("Player")
+        field_list = canvas_group.get_children()
 	
 	body_entered.connect(_on_player_entered)
 	body_exited.connect(_on_player_exited)

--- a/scripts/farming/tierbereich.gd
+++ b/scripts/farming/tierbereich.gd
@@ -1,6 +1,6 @@
 extends Area2D
 
-@onready var player: CharacterBody2D = %Player
+var player: CharacterBody2D
 @onready var door: AnimatedSprite2D = $Area2D/door
 @onready var door_area: Area2D = $Area2D
 @onready var door_collision:CollisionShape2D = $StaticBody2D/CollisionShape2D
@@ -15,8 +15,9 @@ signal feeding_state
 signal collecting_state
 
 func _ready() -> void:
-	if player:
-		player.interact.connect(_on_player_interact)
+        player = get_tree().get_first_node_in_group("Player")
+        if player:
+                player.interact.connect(_on_player_interact)
 	door_area.body_entered.connect(_on_door_entered)
 	door_area.body_exited.connect(_on_door_exited)
 	interact_range.body_entered.connect(_on_interact_entered)


### PR DESCRIPTION
## Summary
- fix missing player warnings across intro scene
- use group-based player lookup instead of `%Player`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840376f44fc83278e1e267453798420